### PR TITLE
docs: theme options addition

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,7 +124,18 @@ html_theme = 'alabaster'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    'description': 'Flask-AppFactory is an dynamic application loader.',
+    'github_user': 'inveniosoftware',
+    'github_repo': 'flask-appfactory',
+    'github_button': False,
+    'github_banner': True,
+    'show_powered_by': False,
+    'extra_nav_links' : {
+        'Flask-AppFactory@GitHub' : 'http://github.com/inveniosoftware/flask-appfactory/',
+        'Flask-AppFactory@PyPI' : 'http://pypi.python.org/pypi/Flask-AppFactory/',
+    }
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []


### PR DESCRIPTION
- Adds theme options to documentation in order to show links to GitHub
  and PyPI.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
