### PR TITLE
tests: optional Celery test cases

### DIFF
--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -12,11 +12,15 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from flask_appfactory import appfactory
-from flask_appfactory.celery import celeryfactory
+
+import pytest
 
 
 def test_dummy_app():
     """"Test celery app creation."""
+    pytest.importorskip("celery")
+    from flask_appfactory.celery import celeryfactory
+
     class conf:
         EXTENSIONS = ['flask_celeryext:FlaskCeleryExt']
 
@@ -29,6 +33,8 @@ def test_dummy_app():
 
 def test_dummy_app_noext():
     """"Test celery app creation without extension."""
+    pytest.importorskip("celery")
+    from flask_appfactory.celery import celeryfactory
     app = appfactory("app3", None)
     celery = celeryfactory(app)
     assert celery


### PR DESCRIPTION
Running tests in a virgin venv gives troubles due to failing Celery test cases:

```
=========================================================== ERRORS ============================================================
____________________________________________ ERROR collecting tests/test_celery.py ____________________________________________
tests/test_celery.py:15: in <module>
    from flask_appfactory.celery import celeryfactory
flask_appfactory/celery.py:14: in <module>
    from flask_celeryext import create_celery_app
E   ImportError: No module named flask_celeryext
____________________________________________ ERROR collecting tests/test_celery.py ____________________________________________
tests/test_celery.py:15: in <module>
    from flask_appfactory.celery import celeryfactory
flask_appfactory/celery.py:14: in <module>
    from flask_celeryext import create_celery_app
E   ImportError: No module named flask_celeryext
```

Since the Celery extras are optional, this PR fixes the problem by skipping these tests when Celery extra insn't installed.
